### PR TITLE
Add dependency on commerce_order_ui.

### DIFF
--- a/modules/rooms_booking_manager/rooms_booking_manager.info
+++ b/modules/rooms_booking_manager/rooms_booking_manager.info
@@ -19,4 +19,5 @@ dependencies[] = commerce_price
 dependencies[] = commerce_cart
 dependencies[] = commerce_line_item
 dependencies[] = commerce_order
+dependencies[] = commerce_order_ui
 dependencies[] = commerce_checkout


### PR DESCRIPTION
If the commerce_order_ui module is not enabled, the link to view your order that is displayed after completing checkout is incorrect. (just points to the checkout page.)
