### PR TITLE
Fix options handling when creating booking line item.

### DIFF
--- a/modules/rooms_booking_manager/rooms_booking_manager.commerce.inc
+++ b/modules/rooms_booking_manager/rooms_booking_manager.commerce.inc
@@ -95,7 +95,7 @@ function rooms_create_line_item($unit_to_book, AvailabilityAgent $agent, $bookin
 
       $price_options = array();
       foreach ($price_modifiers as $mod) {
-        $price_options[LANGUAGE_NONE][0] = array(
+        $price_options[LANGUAGE_NONE][] = array(
           'name' => $mod['#name'],
           'quantity' => 1,
           'operation' => array_search($mod['#op_type'], $operation_list),


### PR DESCRIPTION
The index was incorrectly set when adding price options to the line item, so that only the last selected option was saved. This change allows multiple options to be properly added to the booking.
