### PR TITLE
Issue #2137273: Fallback when there is a booking without name.

### DIFF
--- a/modules/rooms_availability/includes/rooms_availability.booking_event.inc
+++ b/modules/rooms_availability/includes/rooms_availability.booking_event.inc
@@ -221,7 +221,7 @@ class BookingEvent {
       $booking_id = rooms_availability_return_id($this->id);
       $booking = rooms_booking_load($booking_id);
       if ($style == ROOMS_AVAILABILITY_ADMIN_STYLE) {
-        $name = $booking->name;
+        $name = !empty($booking->name) ? $booking->name : t('Booking') . ' :' . $booking->booking_id;
         $interval = $this->diff();
         if ((strlen($name) > 7) && ($interval->d < 1)) {
           $event['title'] = substr($booking->name, 0 , 6) . '...';


### PR DESCRIPTION
https://drupal.org/node/2137273

It seems the reporter, for some reason has a booking where the 'name' column in the table is empty. Resulting in an error inside the json generating function for a date range in the availability calendar, leaving a whole date range without events.

The 'name' column should never be empty, but it is not possible to determine what caused this case. This fix avoids leaving a whole date range empty in the availability calendar, handling this cases more nicely.
