### PR TITLE
Issue #2158843 happens only when use PHP versions < 5.3.6

### DIFF
--- a/modules/rooms_booking/rooms_booking.admin.inc
+++ b/modules/rooms_booking/rooms_booking.admin.inc
@@ -210,7 +210,6 @@ function rooms_booking_edit_profile_callback(&$form, $form_state) {
   return render($form['client']);
 }
 
-
 /**
  * Form callback: create or edit a booking.
  *
@@ -219,7 +218,6 @@ function rooms_booking_edit_profile_callback(&$form, $form_state) {
  *     with only a booking type defined.
  */
 function rooms_booking_edit_form($form, &$form_state, $booking) {
-
   $form['#attributes']['class'][] = 'rooms-management-form rooms-booking-form';
 
   drupal_add_css(drupal_get_path('module', 'rooms_booking') . '/css/rooms_booking.css');
@@ -305,7 +303,7 @@ function rooms_booking_edit_form($form, &$form_state, $booking) {
   $form['data']['group_size_children'] = array(
     '#type' => 'select',
     '#title' => t('Children'),
-    '#options' => range(0, $persons),
+    '#options' => rooms_range(0, $persons),
     '#default_value' =>  isset($booking->data['group_size_children']) ? $booking->data['group_size_children'] : '0',
     '#description' => t('The number of children staying in this unit.'),
     '#prefix' => '<div id="rooms_booking_group_size_children_container">',
@@ -630,7 +628,7 @@ function rooms_booking_edit_form($form, &$form_state, $booking) {
                       $form['availability_fieldset']['unit_fieldset']['options_fieldset'][strtolower(str_replace(array(':', ' '), '_', $option['name'])) . ':quantity'] = array(
                         '#type' => 'select',
                         '#title' => t('Quantity'),
-                        '#options' => range(1, $option['quantity']),
+                        '#options' => rooms_range(1, $option['quantity']),
                         '#ajax' => array(
                           'callback' => 'rooms_booking_select_unit_callback',
                           'wrapper' => 'options-wrapper',

--- a/rooms.module
+++ b/rooms.module
@@ -432,3 +432,22 @@ function rooms_check_dates_validity(DateTime $start_date, DateTime $end_date, $t
   }
   return $errors;
 }
+
+/**
+ * Alternative numeric range generator considering users that use PHP < v5.3.6
+ * and experiment the bug: https://bugs.php.net/bug.php?id=51894
+ * @param int $start
+ * @param int $end
+ */
+function rooms_range($start, $end) {
+  if (version_compare(phpversion(), '5.3.6', '<')) {
+    $range = array();
+    for ($index = $start; $index <= $end; $index++) {
+      $range[] = $index;
+    }
+    return $range;
+  }
+  else {
+    return range($start, $end, 1);
+  }
+}


### PR DESCRIPTION
Ronald - You can consider this patch as a supporting code for users that have PHP versions < 5.3.6 with the consideration that in Rooms there is an extensive use of range() PHP function. The solution for that users is update to greater PHP version but in case we want to broke Rooms on that PHP versions we should consider something like this solution. The decision is at your side.

See: https://drupal.org/node/2158843  and https://bugs.php.net/bug.php?id=51894
