### PR TITLE
ROOMS-251: Theme rooms unit edit form.

### DIFF
--- a/modules/rooms_unit/css/rooms_unit_type.css
+++ b/modules/rooms_unit/css/rooms_unit_type.css
@@ -1,0 +1,47 @@
+/* Bookable unit type edit form */
+.rooms-unit-type-edit-form .form-wrapper {
+  max-width: 400px;
+  margin: 0 20px 0.4em 0;
+}
+.rooms-unit-type-edit-form .form-item {
+  margin-bottom: 1em;
+}
+.rooms-unit-type-edit-form .form-item label,
+.rooms-unit-type-edit-form .form-wrapper legend {
+  margin-bottom: 0.2em;
+}
+.rooms-unit-type-edit-form .form-item label,
+.rooms-unit-type-edit-form .form-wrapper .fieldset-legend {
+  font-size: 1em;
+  font-weight: bold;
+}
+.rooms-unit-type-edit-form .form-checkbox + label {
+  font-weight: normal;
+}
+.rooms-unit-type-edit-form .form-checkbox:checked + label {
+  font-weight: bold;
+}
+.rooms-unit-type-edit-form .field-widget-rooms-options-combined {
+  max-width: inherit;
+  margin-right: 0;
+  clear: both;
+}
+.rooms-unit-type-edit-form .form-actions {
+  clear: both;
+}
+
+.rooms-unit-type-edit-form .form-item-name,
+.rooms-unit-type-edit-form .form-item-data-base-price,
+.rooms-unit-type-edit-form #edit-guest-capacity,
+.rooms-unit-type-edit-form #edit-child-capacity,
+.rooms-unit-type-edit-form #edit-data-bed-arrangement {
+  float: left;
+  width: 15em;
+  margin-right: 20px;
+}
+.rooms-unit-type-edit-form #edit-reference,
+.rooms-unit-type-edit-form #edit-unit-defaults {
+  float: none;
+  width: 100%;
+  max-width: 100%;
+}

--- a/modules/rooms_unit/rooms_unit_type.admin.inc
+++ b/modules/rooms_unit/rooms_unit_type.admin.inc
@@ -28,7 +28,11 @@ class RoomsUnitTypeUIController extends EntityDefaultUIController {
  */
 function rooms_unit_type_form($form, &$form_state, $unit_type, $op = 'edit') {
 
-  $form['#attributes']['class'][] = 'rooms-management-form unit-type-form';
+  $form['#attributes']['class'][] = 'rooms-management-form rooms-unit-type-edit-form';
+
+  $form['#attached']['css'] = array(
+    drupal_get_path('module', 'rooms_unit') . '/css/rooms_unit_type.css',
+  );
 
   if ($op == 'clone') {
     $unit_type->label .= ' (cloned)';
@@ -36,7 +40,7 @@ function rooms_unit_type_form($form, &$form_state, $unit_type, $op = 'edit') {
   }
 
   $form['label'] = array(
-    '#title' => t('Label'),
+    '#title' => t('Unit type name'),
     '#type' => 'textfield',
     '#default_value' => $unit_type->label,
     '#description' => t('The human-readable name of this unit type.'),
@@ -56,63 +60,86 @@ function rooms_unit_type_form($form, &$form_state, $unit_type, $op = 'edit') {
     '#description' => t('A unique machine-readable name for this unit type. It must only contain lowercase letters, numbers, and underscores.'),
   );
 
-  $form['data']['#tree'] = TRUE;
+  $form['unit_defaults'] = array(
+    '#type' => 'fieldset',
+    '#description' => '<strong>' . t('Unit defaults') . '</strong> - ' . t('Values specified below will be pre-populated as the defaults when creating units of this type.'),
+    '#tree' => FALSE,
+  );
 
-  $form['data']['base_price'] = array(
+  $form['unit_defaults']['data']['#tree'] = TRUE;
+
+  $form['unit_defaults']['data']['base_price'] = array(
     '#type' => 'textfield',
-    '#title' => t('Unit base price'),
+    '#title' => t('Default base price'),
     '#default_value' => isset($unit_type->data['base_price']) ? $unit_type->data['base_price'] : '',
-    '#size' => '5',
+    '#size' => 5,
     '#field_suffix' => t('Per unit per night'),
-    '#description' => t('The price you set here will be the default price for all units of this type. You may then change the default base price on a per unit basis.'),
+    '#description' => t('The default base price is used for all units of this type and may be changed on the edit form of each unit individually.'),
     '#maxlength' => 10,
   );
 
-  $form['data']['min_sleeps'] = array(
+  $form['unit_defaults']['guest_capacity'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Default sleeping capacity'),
+    '#tree' => FALSE,
+  );
+
+  $form['unit_defaults']['guest_capacity']['data']['#tree'] = TRUE;
+
+  $form['unit_defaults']['guest_capacity']['data']['min_sleeps'] = array(
     '#type' => 'textfield',
-    '#title' => t('Sleeping capacity'),
+    '#size' => 5,
     '#default_value' => isset($unit_type->data['min_sleeps']) ? $unit_type->data['min_sleeps'] : '',
-    '#size' => '5',
-    '#maxlength' => 2,
-    '#field_prefix' => t('Minimum') . ':',
+    '#field_suffix' => t('Person minimum'),
   );
 
-  $form['data']['max_sleeps'] = array(
+  $form['unit_defaults']['guest_capacity']['data']['max_sleeps'] = array(
     '#type' => 'textfield',
+    '#size' => 5,
     '#default_value' => isset($unit_type->data['max_sleeps']) ? $unit_type->data['max_sleeps'] : '',
-    '#size' => '5',
-    '#description' => t('The default number of people (including adults and children) for each unit of this type.'),
-    '#maxlength' => 2,
-    '#field_prefix' => t('Maximum') . ':',
+    '#description' => t('The default number of guests (including adults and children) for each unit of this type.'),
+    '#field_suffix' => t('Person maximum'),
   );
 
-  $form['data']['min_children'] = array(
+  $form['unit_defaults']['child_capacity'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Default child capacity'),
+    '#tree' => FALSE,
+  );
+
+  $form['unit_defaults']['child_capacity']['data']['#tree'] = TRUE;
+
+  $form['unit_defaults']['child_capacity']['data']['min_children'] = array(
     '#type' => 'textfield',
-    '#title' => t('Child capacity'),
+    '#size' => 5,
     '#default_value' => isset($unit_type->data['min_children']) ? $unit_type->data['min_children'] : '',
-    '#size' => '5',
-    '#maxlength' => 2,
-    '#field_prefix' => t('Minimum') . ':',
+    '#field_suffix' => t('Child minimum'),
   );
 
-  $form['data']['max_children'] = array(
+  $form['unit_defaults']['child_capacity']['data']['max_children'] = array(
     '#type' => 'textfield',
+    '#size' => 5,
     '#default_value' => isset($unit_type->data['max_children']) ? $unit_type->data['max_children'] : '',
-    '#size' => '5',
     '#description' => t('The default number of children per unit of this type.'),
-    '#maxlength' => 2,
-    '#field_prefix' => t('Maximum') . ':',
+    '#field_suffix' => t('Child maximum'),
   );
 
-  $form['data']['rooms_description_source'] = array(
+  $form['reference'] = array(
+    '#type' => 'fieldset',
+    '#tree' => FALSE,
+  );
+
+  $form['reference']['data']['#tree'] = TRUE;
+
+  $form['reference']['data']['rooms_description_source'] = array(
     '#type' => 'textfield',
-    '#title' => t('Select Unit Description source'),
+    '#title' => t('Unit type description source'),
     '#description' => t('The node you choose here will be rendered in the booking results.'),
     '#size' => 30,
     '#maxlength' => 60,
     '#autocomplete_path' => 'admin/rooms/unit-type/description-source',
     '#default_value' => isset($unit_type->data['rooms_description_source']) ? $unit_type->data['rooms_description_source'] : '',
-    '#weight' => 3,
+    '#weight' => 99,
   );
 
   $form['actions'] = array(
@@ -122,7 +149,7 @@ function rooms_unit_type_form($form, &$form_state, $unit_type, $op = 'edit') {
   $form['actions']['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save unit type'),
-    '#weight' => 40,
+    '#weight' => 100,
   );
 
   //Locking not supported yet


### PR DESCRIPTION
@istos, this commit adds similar styling for the Unit Type Edit form as that found on the Unit Edit form.

I had to do some jiggerhoochy  to wrap some of the form elements inside additional fieldsets that allowed for this layout while maintaining the "data" wrapper element "#tree" (which is required for the auto-save array/object magic on form submit).  This could look cleaner if we could get that intermediate "data" thingy out of there, but this is an exercise I'll leave to maybe @plopesc, seems low priority.

![rooms-251](https://cloud.githubusercontent.com/assets/243532/2830450/c32b9e50-cfae-11e3-8436-e2f1f5137f7b.png)
