### PR TITLE
Issue #2445673

### DIFF
--- a/rooms.info
+++ b/rooms.info
@@ -10,6 +10,9 @@ files[] = includes/rooms.event_interface.inc
 
 package = Rooms
 
-dependencies[] = libraries (>=2.x)
+dependencies[] = date
+dependencies[] = date_api
+dependencies[] = date_popup
 dependencies[] = jquery_update
+dependencies[] = libraries (>=2.x)
 dependencies[] = variable


### PR DESCRIPTION
Original issue: https://www.drupal.org/node/2445673

Quite a few rooms modules call rooms_date_range_fields(), seems simplest to specify the dependency in rooms.info?

@istos 