### PR TITLE
rooms_booking_delete_multiple $delete_line_item

### DIFF
--- a/modules/rooms_booking/rooms_booking.module
+++ b/modules/rooms_booking/rooms_booking.module
@@ -765,7 +765,7 @@ function rooms_booking_commerce_order_delete($order) {
  *   Flag indicating if the associated line_item should be deleted or not.
  */
 function rooms_booking_delete_multiple(array $booking_ids, $delete_line_item = TRUE) {
-  entity_get_controller('rooms_booking')->delete($booking_ids);
+  entity_get_controller('rooms_booking')->delete($booking_ids, $delete_line_item);
 }
 
 /**


### PR DESCRIPTION
The $delete_line_item parameter was not passed to the controller, thus it was not allowing to leave the line items into the order, thus was not allowing to leave the order intact when deleting the booking.
